### PR TITLE
Coverage 4.0 doesn't support Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,11 @@ python:
   - "pypy"
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
 install:
   - python setup.py -q install
 
-  # Coverage 4.0 doesn't support Python 3.2
-  - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then pip install coverage==3.7.1; fi
-  - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then pip install coverage; fi
-
+  - pip install coverage
   - pip install pytest-cov
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip install sphinx; fi
 script:
@@ -20,4 +16,5 @@ script:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then python -m doctest README.rst; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then sphinx-build -b doctest docs _temp; fi
 after_success:
+  - pip install coveralls
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,12 @@ python:
   - "3.3"
 install:
   - python setup.py -q install
-  - pip install pytest-cov coveralls
+
+  # Coverage 4.0 doesn't support Python 3.2
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then pip install coverage==3.7.1; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then pip install coverage; fi
+
+  - pip install pytest-cov
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip install sphinx; fi
 script:
   - py.test tests.py --cov jsonref --cov proxytypes --cov-report term-missing

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ jsonref
 
 ``jsonref`` is a library for automatic dereferencing of
 `JSON Reference <http://tools.ietf.org/id/draft-pbryan-zyp-json-ref-03.html>`_
-objects for Python (supporting 2.6+ including Python 3).
+objects for Python (supporting Python 2.6+ and Python 3.3+).
 
 This library lets you use a data structure with JSON reference objects, as if
 the references had been replaced with the referent data.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ jsonref
 
 ``jsonref`` is a library for automatic dereferencing of
 `JSON Reference <http://tools.ietf.org/id/draft-pbryan-zyp-json-ref-03.html>`_
-objects for Python (supporting 2.6+ including Python 3).
+objects for Python (supporting Python 2.6+ and Python 3.3+).
 
 .. testcode::
 

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,6 @@ classifiers = [
     "Programming Language :: Python :: 2.6",
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.1",
-    "Programming Language :: Python :: 3.2",
     "Programming Language :: Python :: 3.3",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
So use the last supported version for Python 3.2.

Fixes https://github.com/gazpachoking/jsonref/issues/10.