### PR TITLE
Add Python 3.4 and 3.5 and PyPy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: python
 python:
   - "pypy"
+  - "pypy3"
   - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
+  - "3.5"
 install:
   - python setup.py -q install
   - pip install pytest-cov coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,8 @@ script:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then sphinx-build -b doctest docs _temp; fi
 after_success:
   - coveralls
+matrix:
+  fast_finish: true
+  allow_failures:
+    - python: pypy
+    - python: pypy3


### PR DESCRIPTION
But whilst pypy and pypy3 are unsupported, don't let them fail the builds.

When they're fixed, remove them from `allow_failures`.