### PR TITLE
.gitignore and container-based infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,90 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+.venv/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+
 python:
   - "pypy"
   - "pypy3"
@@ -8,17 +9,24 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+
+# Use container-based infrastructure
+sudo: false
+
 install:
   - python setup.py -q install
   - pip install pytest-cov coveralls
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip install sphinx; fi
+
 script:
   - py.test tests.py --cov jsonref --cov proxytypes --cov-report term-missing
   # Docs are in python 3 format
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then python -m doctest README.rst; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then sphinx-build -b doctest docs _temp; fi
+
 after_success:
   - coveralls
+
 matrix:
   fast_finish: true
   allow_failures:


### PR DESCRIPTION
* Uses https://github.com/github/gitignore/blob/master/Python.gitignore to make sure things like these are not committed:

        .coverage
        .hypothesis/
        __pycache__/
        jsonref.pyc
        proxytypes.pyc


* Container-based infrastructure for faster builds:
https://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/