### PR TITLE
JsonRefError: add __str__ helper

### DIFF
--- a/jsonref.py
+++ b/jsonref.py
@@ -52,6 +52,9 @@ class JsonRefError(Exception):
     def __repr__(self):
         return "<%s: %r>" % (self.__class__.__name__, self.message)
 
+    def __str__(self):
+        return str(self.message)
+
 
 class JsonRef(LazyProxy):
     """


### PR DESCRIPTION
When JsonRefError is raised today, the default error message is not helpful:
  File ".../jsonref.py", line 221, in _error
    cause=cause
jsonref.JsonRefError

Let's include the message in the __str__ helper so we get:
  File ".../jsonref.py", line 221, in _error
    cause=cause
jsonref.JsonRefError: ValueError: unknown url type: defs.json