### PR TITLE
Fix escaping in JSON pointers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ cache: pip
 # Jump through some hoops to get both python 3.7 and older versions running
 matrix:
   include:
-    - python: "2.6"
     - python: "2.7"
-    - python: "3.3"
     - python: "3.4"
     - python: "3.5"
     - python: "3.6"

--- a/jsonref.py
+++ b/jsonref.py
@@ -1,7 +1,6 @@
 import functools
 import json
 import operator
-import re
 import sys
 import warnings
 
@@ -196,17 +195,11 @@ class JsonRef(LazyProxy):
         :argument str pointer: a json pointer URI fragment to resolve within it
 
         """
-        # Do only split at single forward slashes which are not prefixed by a caret
-        parts = re.split(r"(?<!\^)/", unquote(pointer.lstrip("/"))) if pointer else []
+        parts = unquote(pointer.lstrip("/")).split("/") if pointer else []
 
         for part in parts:
-            # Restore escaped slashes and carets
-            replacements = {r"^/": r"/", r"^^": r"^"}
-            part = re.sub(
-                "|".join(re.escape(key) for key in replacements.keys()),
-                lambda k: replacements[k.group(0)],
-                part,
-            )
+            part = part.replace("~1", "/").replace("~0", "~")
+
             if isinstance(document, Sequence):
                 # Try to turn an array index to an int
                 try:

--- a/tests.py
+++ b/tests.py
@@ -46,6 +46,13 @@ class TestJsonRef(object):
         json = {"a": [5, 15], "b": {"$ref": "#/a/1"}}
         assert JsonRef.replace_refs(json)["b"] == json["a"][1]
 
+    def test_local_escaped_ref(self):
+        json = {
+            "a/~a": ["resolved"],
+            "b": {"$ref": '#/a~1~0a'}
+        }
+        assert JsonRef.replace_refs(json)["b"] == json["a/~a"]
+
     def test_local_nonexistent_ref(self):
         json = {
             "data": [1, 2],


### PR DESCRIPTION
#13 refers old draft specification. [RFC 6901](https://tools.ietf.org/html/rfc6901#section-3) says:

```
   Because the characters '~' (%x7E) and '/' (%x2F) have special
   meanings in JSON Pointer, '~' needs to be encoded as '~0' and '/'
   needs to be encoded as '~1' when these characters appear in a
   reference token.
```