### PR TITLE
Support schemas that start with a ref to an internal definition

### DIFF
--- a/jsonref.py
+++ b/jsonref.py
@@ -207,16 +207,22 @@ class JsonRef(LazyProxy):
                 lambda k: replacements[k.group(0)],
                 part,
             )
-            if isinstance(document, Sequence):
-                # Try to turn an array index to an int
+            if isinstance(document, JsonRef):
+                document = JsonRef.replace_refs(document.__reference__[part], _recursive=True,
+                                                base_uri=document.__reference__['$id'],
+                                                loader=self.loader)
+#                                                **document.kwargs)
+            else:
+                if isinstance(document, Sequence):
+                    # Try to turn an array index to an int
+                    try:
+                        part = int(part)
+                    except ValueError:
+                        pass
                 try:
-                    part = int(part)
-                except ValueError:
-                    pass
-            try:
-                document = document[part]
-            except (TypeError, LookupError) as e:
-                self._error("Unresolvable JSON pointer: %r" % pointer, cause=e)
+                    document = document[part]
+                except (TypeError, LookupError) as e:
+                    self._error("Unresolvable JSON pointer: %r" % pointer, cause=e)
         return document
 
     def _error(self, message, cause=None):


### PR DESCRIPTION
For jsonschema examples like the following, the current version of jsonschema repeatedly trips over the first '$ref' and never ends up parsing the definitions: clause which would have defined the reference.  This PR avoids this by scanning the document.__reference__ when necessary.

```json
{
  "$schema": "http://json-schema.org/schema#",
  "$id": "http://schema.someplace.org/code_provenance_info_schema.json",
  "title": "code provenance info schema",
  "description": "code provenance info schema",
  "$ref": "#/definitions/code_provenance_info",
  "definitions": {
    "code_provenance_info": {
      "type": "object",
      "description": "a list of filenames and the git hashes of the versions used",
      "patternProperties": {
        "^[^/]+$": {
          "type": "string",
          "pattern": "^[a-fA-F0-9]+$"
        }
      }
    }
  }
}
```

