### PR TITLE
Preserve extra sibling attributes

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -64,6 +64,18 @@ class TestJsonRef(object):
         assert result["c"].__subject__ is result["a"]
         assert result["d"].__subject__ is result["a"]
 
+    def test_ignored_sibling_attributes(self):
+        json = {
+            "a": {"type": "object", "properties": {"foo": {"type": "string"}}},
+           "b": {"extra": "foobar", "$ref": "#/a"},
+        }
+        result = JsonRef.replace_refs(json)
+        assert result["b"].__subject__ is {
+            "extra": "foobar",
+            "type": "object",
+            "properties": {"foo": {"type": "string"}},
+        }
+
     def test_recursive_data_structures_local(self):
         json = {"a": "foobar", "b": {"$ref": "#"}}
         result = JsonRef.replace_refs(json)

--- a/tests.py
+++ b/tests.py
@@ -69,6 +69,7 @@ class TestJsonRef(object):
             "a": {"type": "object", "properties": {"foo": {"type": "string"}}},
             "b": {"extra": "foobar", "$ref": "#/a"},
             "c": {"extra": { "more": "bar", "$ref": "#/a"} },
+            "d": {"deep":  { "$ref": "#/a", "more": { "$ref": "#/b" } } },
         }
         result = JsonRef.replace_refs(json)
         # because we deepcopy, use '==' instead of 'is"
@@ -80,6 +81,17 @@ class TestJsonRef(object):
         assert result["c"] == {
             "extra": {
                 "more": "bar",
+                "type": "object",
+                "properties": {"foo": {"type": "string"}}
+            }
+        }
+        assert result["d"] == {
+            "deep": {
+                "more": {
+                    "extra": "foobar",
+                    "type": "object",
+                    "properties": {"foo": {"type": "string"}},
+                },
                 "type": "object",
                 "properties": {"foo": {"type": "string"}}
             }


### PR DESCRIPTION
Per #23 this change will preserve sibling attributes to the `$ref` attribute on JSON object instances.

I recognize that the JSON RFC language about 

> Any members other than "$ref" in a JSON Reference object SHALL be ignored.

is ambiguous. What does it mean to "ignore" members? Does it mean "pretend they are not there" or does it mean "do not act on or alter them"? I dunno.

What I do know is that other JSON libraries, both in Python and other languages, seem to take the "do not act on or alter them" interpretation of "ignore" so that's what this change does.

You'll note that I use `deepcopy` and so I may be breaking some of the lazy-ness of the proxy pattern. It also means that the test pattern of asserting with `is` against `__subject__` no longer works because it's a copy of the values, not a pointer at the same object.

Happy to discuss a different approach that achieves the same ends of preserving the sibling attributes.