### PR TITLE
Refactor to allow eager loading, or no proxies at all (1.0.0 beta)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,7 @@ doctest_global_setup = dedent(
 """
 )
 
-intersphinx_mapping = {"python": ("https://docs.python.org/3.3", None)}
+intersphinx_mapping = {"python": ("https://docs.python.org/3.10", None)}
 
 
 # -- Options for HTML output ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,9 +57,10 @@ like this::
     from pathlib import Path
     import jsonref
 
-    file_a_path = Path("file-a.json")
+    file_a_path = Path("file-a.json").absolute()
 
-    print(jsonref.load(file_a_path.open(), base_uri=file_a_path.absolute().as_uri()))
+    with file_a_path.open() as file_a:
+        result = jsonref.load(file_a, base_uri=file_a_path.as_uri())
 
 
 :class:`JsonRef` Objects

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,63 @@ seen below.
 
 .. autofunction:: replace_refs
 
+The different modes
+-------------------
+
+``proxies``
+^^^^^^^^^^^
+
+The default mode (``proxies=True``) uses :class:`JsonRef` proxy objects to replace the
+reference objects in the document. For most purposes, they proxy everything to the
+referenced document. This can be useful for a few reasons:
+
+- The original reference object is still available with the
+  :attr:`JsonRef.__reference__` attribute.
+- :func:`dump` and :func:`dumps` can be used to output the document again, with the
+  references still intact. (Including changes made.)
+
+If you are using a tool that does not play nicely with the :class:`JsonRef` proxy
+objects, they can be turned off completely using ``proxies=False``. This is needed e.g.
+if you want to pass the data back to the stdlib :func:`json.dump` function.
+
+``lazy_load`` and ``load_on_repr``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, the references will not actually be resolved until the data is accessed
+(``lazy_load=True``.) This can be useful to limit the upfront processing of deeply
+nested, or otherwise complicated reference trees. To limit the lookups even more, the
+``load_on_repr`` argument can be set to ``False``, so that printing the document will
+not cause the references to load (this can be especially useful when debugging.) The
+downside of this mode is that exceptions when a reference cannot be loaded might be
+issued from more places when using the loaded document. Turning off lazy loading can
+make catching errors much easier.
+
+``merge_props``
+^^^^^^^^^^^^^^^
+
+When using this mode, extra properties from the reference object will be merged into
+the referenced document. e.g.::
+
+    >>> json = {
+        "a": {"$ref": "#/b", "extra": "blah"},
+        "b": {"real": "b"}
+    }
+    >>> print(replace_refs(json, merge_props=True))
+    {
+        "a": {"real": "b", "extra": "blah"},
+        "b": {"real": "b"}
+    }
+    >>> print(replace_refs(json))
+    {
+        "a": {"real": "b"},
+        "b": {"real": "b"}
+    }
+
+This is against the JSON reference spec, but some other JSON reference libraries also
+implement this behavior. It can be useful to e.g. extend common JSON schemas with extra
+properties. This behavior should not be used if you want your JSON documents to be
+usable with the widest possible array of tools.
+
 A note on ``base_uri``
 --------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,27 @@ seen below.
 
 .. autofunction:: replace_refs
 
+A note on ``base_uri``
+--------------------
+
+A common question is how to reference other documents from the local filesystem. This is
+easy if you provide the correct ``base_uri`` to the :func:`replace_refs` function (or
+the other utility functions.) For example, if you have several files in a folder like
+this::
+
+    file-a.json
+    file-b.json
+
+If ``file-a.json`` has a reference like ``{"$ref": "file-b.json"}`` you could load them
+like this::
+
+    from pathlib import Path
+    import jsonref
+
+    file_a_path = Path("file-a.json")
+
+    print(jsonref.load(file_a_path.open(), base_uri=file_a_path.absolute().as_uri()))
+
 
 :class:`JsonRef` Objects
 ========================
@@ -80,6 +101,29 @@ instance of it will be used for all refs unless a custom one is specified.
 
 .. autoclass:: JsonLoader
     :members: __call__
+
+Custom Loaders
+----------
+
+If you want to support custom references, you can define your own loader. For example
+here is a complete script to load `env:XXX` URIs from environment variables::
+
+    import os
+
+    import jsonref
+
+
+    def loader(uri):
+        if uri.startswith("env:"):
+            return os.environ[uri[4:]]
+        # Fall back to the default loader:
+        return jsonref.jsonloader(uri)
+
+    json_w_refs = {
+        "a": {"$ref": "env:MYENVVAR"}
+    }
+
+    result = jsonref.replace_refs(json, loader=loader)
 
 
 :mod:`json` module drop in replacement functions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,12 +8,12 @@ jsonref
 
 ``jsonref`` is a library for automatic dereferencing of
 `JSON Reference <https://tools.ietf.org/id/draft-pbryan-zyp-json-ref-03.html>`_
-objects for Python (supporting Python 2.6+ and Python 3.3+).
+objects for Python (supporting Python 3.3+).
 
 .. testcode::
 
     from pprint import pprint
-    from jsonref import JsonRef
+    from jsonref import replace_refs
 
     # Sample JSON data, like from json.load
     document = {
@@ -21,13 +21,24 @@ objects for Python (supporting Python 2.6+ and Python 3.3+).
         "reference": {"$ref": "#/data/1"}
     }
 
-    # The JsonRef.replace_refs class method will return a copy of the document
+    # The :func:`replace_refs` function will return a copy of the document
     # with refs replaced by :class:`JsonRef` objects
-    pprint(JsonRef.replace_refs(document))
+    pprint(replace_refs(document))
 
 .. testoutput::
 
     {'data': ['a', 'b', 'c'], 'reference': 'b'}
+
+
+The :func:`replace_refs` function
+=================================
+
+The primary interface to use jsonref is with the function :func:`replace_refs`.
+It will return a copy of an object you pass it, with all JSON references contained
+replaced by :class:`JsonRef` objects. There are several other options you can pass,
+seen below.
+
+.. autofunction:: replace_refs
 
 
 :class:`JsonRef` Objects
@@ -39,14 +50,7 @@ pointing to, but only look up that data the first time they are accessed. Once
 JSON reference objects have been substituted in your data structure, you can
 use the data as if it does not contain references at all.
 
-The primary interface to use :class:`JsonRef` objects is with the class method
-:meth:`JsonRef.replace_refs`. It will return a copy of an object you pass it, with
-all JSON references contained replaced by :class:`JsonRef` objects. There are
-several other options you can pass, seen below.
-
 .. autoclass:: JsonRef(refobj, base_uri=None, loader=None, jsonschema=False, load_on_repr=True)
-
-    .. automethod:: replace_refs(obj, base_uri=None, loader=None, jsonschema=False, load_on_repr=True)
 
     :class:`JsonRef` instances proxy almost all operators and attributes to the
     referent data, which will be loaded when first accessed. The following

--- a/jsonref.py
+++ b/jsonref.py
@@ -269,7 +269,8 @@ class JsonLoader(object):
                 result = resp.json()
         else:
             # Otherwise, pass off to urllib and assume utf-8
-            result = json.loads(urlopen(uri).read().decode("utf-8"), **kwargs)
+            with urlopen(uri) as content:
+                result = json.loads(content.read().decode("utf-8"), **kwargs)
 
         return result
 

--- a/jsonref.py
+++ b/jsonref.py
@@ -17,7 +17,7 @@ except ImportError:
 
 from proxytypes import LazyProxy
 
-__version__ = "0.4.dev0"
+__version__ = "1.0.0b2"
 
 
 class JsonRefError(Exception):

--- a/jsonref.py
+++ b/jsonref.py
@@ -136,7 +136,6 @@ class JsonRef(LazyProxy):
             kwargs["base_uri"] = uri
             kwargs["recursing"] = False
             base_doc = _replace_refs(base_doc, **kwargs)
-            self.store[uri] = base_doc
             result = self.resolve_pointer(base_doc, fragment)
         if result is self:
             raise self._error("Reference refers directly to itself.")

--- a/jsonref.py
+++ b/jsonref.py
@@ -167,8 +167,9 @@ class JsonRef(LazyProxy):
             kwargs["base_uri"] = uri
             base_doc = JsonRef.replace_refs(base_doc, **kwargs)
             result = self.resolve_pointer(base_doc, fragment)
+        if result is self:
+            raise self._error("Reference refers directly to itself.")
         if hasattr(result, "__subject__"):
-            # TODO: Circular ref detection
             result = result.__subject__
         return result
 

--- a/jsonref.py
+++ b/jsonref.py
@@ -260,17 +260,17 @@ def jsonloader(uri, **kwargs):
 _no_result = object()
 
 
-def walk_refs(obj, func, replace=False):
+def _walk_refs(obj, func, replace=False):
     if type(obj) is JsonRef:
         return func(obj)
     if isinstance(obj, Mapping):
         for k, v in obj.items():
-            r = walk_refs(v, func, replace=replace)
+            r = _walk_refs(v, func, replace=replace)
             if r is not _no_result and replace:
                 obj[k] = r
     elif isinstance(obj, Sequence) and not isinstance(obj, str):
         for i, v in enumerate(obj):
-            r = walk_refs(v, func, replace=replace)
+            r = _walk_refs(v, func, replace=replace)
             if r is not _no_result and replace:
                 obj[i] = r
     return _no_result
@@ -329,9 +329,9 @@ def replace_refs(
         recursing=False,
     )
     if not proxies:
-        walk_refs(result, lambda r: r.__subject__, replace=True)
+        _walk_refs(result, lambda r: r.__subject__, replace=True)
     elif not lazy_load:
-        walk_refs(result, lambda r: r.__subject__)
+        _walk_refs(result, lambda r: r.__subject__)
     return result
 
 

--- a/jsonref.py
+++ b/jsonref.py
@@ -100,7 +100,7 @@ class JsonRef(LazyProxy):
         self.path = _path
         self.store = _store  # Use the same object to be shared with children
         if self.store is None:
-            self.store = _URIDict()
+            self.store = URIDict()
 
     @property
     def _ref_kwargs(self):
@@ -187,10 +187,9 @@ class JsonRef(LazyProxy):
         return "JsonRef(%r)" % self.__reference__
 
 
-class _URIDict(MutableMapping):
+class URIDict(MutableMapping):
     """
     Dictionary which uses normalized URIs as keys.
-
     """
 
     def normalize(self, uri):
@@ -337,7 +336,7 @@ def replace_refs(
         loader=loader,
         jsonschema=jsonschema,
         load_on_repr=load_on_repr,
-        store=_URIDict(),
+        store=URIDict(),
         path=(),
         recursing=False,
     )

--- a/jsonref.py
+++ b/jsonref.py
@@ -282,12 +282,12 @@ _no_result = object()
 def walk_refs(obj, func, replace=False):
     if type(obj) is JsonRef:
         return func(obj)
-    if isinstance(obj, dict):
+    if isinstance(obj, Mapping):
         for k, v in obj.items():
             r = walk_refs(v, func, replace=replace)
             if r is not _no_result and replace:
                 obj[k] = r
-    elif isinstance(obj, list):
+    elif isinstance(obj, Sequence) and not isinstance(obj, str):
         for i, v in enumerate(obj):
             r = walk_refs(v, func, replace=replace)
             if r is not _no_result and replace:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ python = "^3.3"
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.3"
 
+[tool.poetry_bumpversion.file."jsonref.py"]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jsonref"
-version = "1.0.0b2"
+version = "1.0.0b3"
 description = "jsonref is a library for automatic dereferencing of JSON Reference objects for Python."
 authors = ["Chase Sterling <chase.sterling@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jsonref"
-version = "0.4.dev0"
+version = "1.0.0b1"
 description = "jsonref is a library for automatic dereferencing of JSON Reference objects for Python."
 authors = ["Chase Sterling <chase.sterling@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jsonref"
-version = "1.0.0b1"
+version = "1.0.0b2"
 description = "jsonref is a library for automatic dereferencing of JSON Reference objects for Python."
 authors = ["Chase Sterling <chase.sterling@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,6 @@ pytest = "^7.1.3"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.isort]
+profile = "black"

--- a/tests.py
+++ b/tests.py
@@ -93,6 +93,28 @@ class TestJsonRef(object):
             "type": "object",
             "properties": {"foo": {"type": "string"}},
         }
+        assert result["c"] == {
+            "extra": {
+                "more": "bar",
+                "type": "object",
+                "properties": {"foo": {"type": "string"}},
+            }
+        }
+
+    def test_extra_sibling_attributes_list_ref(self):
+        json = {
+            "a": ["target"],
+            "b": {"extra": "foobar", "$ref": "#/a"},
+        }
+        result = replace_refs(json)
+        with pytest.raises(JsonRefError) as excinfo:
+            result["b"].__subject__
+        e = excinfo.value
+        assert e.reference == json["b"]
+        assert e.uri == "#/a"
+        assert e.base_uri == ""
+        assert e.path == ["b"]
+        assert type(e.cause) == TypeError
 
     def test_lazy_load(self):
         json = {

--- a/tests.py
+++ b/tests.py
@@ -331,7 +331,9 @@ class TestJsonLoader(object):
 
         with mock.patch("jsonref.requests", None):
             with mock.patch("jsonref.urlopen") as urlopen:
-                urlopen.return_value.read.return_value = json.dumps(data).encode("utf8")
+                urlopen.return_value.__enter__.return_value.read.return_value = (
+                    json.dumps(data).encode("utf8")
+                )
                 result = self.loader(ref)
                 assert result == data
         urlopen.assert_called_once_with("http://bar")

--- a/tests.py
+++ b/tests.py
@@ -87,9 +87,9 @@ class TestJsonRef(object):
             "a": {"main": 1},
             "b": {"$ref": "#/a", "extra": 2},
         }
-        no_extra = parametrized_replace_refs(json, merge_extra_properties=False)
+        no_extra = parametrized_replace_refs(json, merge_props=False)
         assert no_extra == {"a": {"main": 1}, "b": {"main": 1}}
-        extra = parametrized_replace_refs(json, merge_extra_properties=True)
+        extra = parametrized_replace_refs(json, merge_props=True)
         assert extra == {"a": {"main": 1}, "b": {"main": 1, "extra": 2}}
 
     def test_extra_ref_attributes(self, parametrized_replace_refs):
@@ -98,9 +98,7 @@ class TestJsonRef(object):
             "b": {"extra": "foobar", "$ref": "#/a"},
             "c": {"extra": {"more": "bar", "$ref": "#/a"}},
         }
-        result = parametrized_replace_refs(
-            json, load_on_repr=False, merge_extra_properties=True
-        )
+        result = parametrized_replace_refs(json, load_on_repr=False, merge_props=True)
         assert result["b"] == {
             "extra": "foobar",
             "type": "object",
@@ -116,7 +114,7 @@ class TestJsonRef(object):
 
     def test_recursive_extra(self, parametrized_replace_refs):
         json = {"a": {"$ref": "#", "extra": "foo"}}
-        result = parametrized_replace_refs(json, merge_extra_properties=True)
+        result = parametrized_replace_refs(json, merge_props=True)
         assert result["a"]["a"]["extra"] == "foo"
         assert result["a"]["a"] is result["a"]["a"]["a"]
 
@@ -125,7 +123,7 @@ class TestJsonRef(object):
             "a": ["target"],
             "b": {"extra": "foobar", "$ref": "#/a"},
         }
-        result = parametrized_replace_refs(json, merge_extra_properties=True)
+        result = parametrized_replace_refs(json, merge_props=True)
         assert result["b"] == result["a"]
 
     def test_separate_extras(self, parametrized_replace_refs):
@@ -135,7 +133,7 @@ class TestJsonRef(object):
             "y": {"$ref": "#/a", "extray": "y"},
             "z": {"$ref": "#/y", "extraz": "z"},
         }
-        result = parametrized_replace_refs(json, merge_extra_properties=True)
+        result = parametrized_replace_refs(json, merge_props=True)
         assert result == {
             "a": {"main": 1234},
             "x": {"main": 1234, "extrax": "x"},

--- a/tests.py
+++ b/tests.py
@@ -82,6 +82,18 @@ class TestJsonRef(object):
         assert result["c"].__subject__ is result["a"]
         assert result["d"].__subject__ is result["a"]
 
+    def test_ignored_sibling_attributes(self):
+        json = {
+            "a": {"type": "object", "properties": {"foo": {"type": "string"}}},
+            "b": {"extra": "foobar", "$ref": "#/a"},
+        }
+        result = replace_refs(json)
+        assert result["b"].__subject__ is {
+            "extra": "foobar",
+            "type": "object",
+            "properties": {"foo": {"type": "string"}},
+        }
+
     def test_lazy_load(self):
         json = {
             "a": {"$ref": "#/fake"},


### PR DESCRIPTION
A couple things going on in this PR.

The main interface has been changed from `JsonRef.replace_refs` to a top level function `replace_refs`. Just feels like it makes more sense, and I can't remember why it was a class method to start with. Also fixes (#22). `JsonRef.replace_refs` is deprecated, but still works for now.

`jsonloader` has had the caching removed, and turned into a plain function rather than an instance of a special class. Caching of ref results is now handled directly by `replace_refs`. The previous caching behavior was a bit muddled, and this makes it easier for custom loaders to be implemented without worrying about caching. There is now no way to turn off caching (which was mostly the case previously as well, some of the caching was required for basic functionality.) If you want to pre-cache some URIs, it can be done by creating a custom loader function that loads from said cache.

Due to multiple issues filed, three new options were added to `replace_refs`:
- The `lazy_load` option. When set to False, all references will be eagerly loaded. This can be useful because any errors will happen right on initial load, rather than when the reference is eventually accessed.
- The `proxies` option. When set to False, the resulting document won't have `JsonRef` objects in it at all, they will be replaced by the actual referred to data (#9, #31). This can be nice when using with another library that doesn't work properly with the proxy objects, e.g. using `json.dump` to output the document with the refs replaced (#41). If used, this will of course mean you will be unable to output the document again with the refs intact. 
- The `merge_props` argument. This was based on #35, and allows extra properties of json reference objects to be merged in to the document loaded by the reference. This is not part of the JSON reference spec, so is turned off by default.

I'm hoping for some feedback on this PR, and testing by anyone using the repo. I might make a beta release on pypi for easier testing if needed. Open questions:
- [x] Is this a good plan?
- [ ] Should the default values for `lazy_load` or `proxies` be changed? My inclination would be to make the default still use proxies, but to eagerly load, so that all errors happen immediately.
- [x] I added a `walk_refs` helper function, which is used internally to support these two new options this will recursively run a function on any `JsonRefs` in an object, (and optionally replace them with the result of the function.) Is this useful to make a public helper function, or is it not needed since the new options will use it directly?