### PR TITLE
Allow self referential references

### DIFF
--- a/jsonref.py
+++ b/jsonref.py
@@ -362,13 +362,8 @@ def _replace_refs(
             base_uri = urlparse.urljoin(base_uri, id_)
             store_uri = base_uri
 
-    try:
-        if not isinstance(obj["$ref"], str):
-            raise TypeError
-    except (TypeError, LookupError):
-        pass
-    else:
-        return JsonRef(
+    if isinstance(obj, Mapping) and isinstance(obj.get("$ref"), str):
+        obj = JsonRef(
             obj,
             base_uri=base_uri,
             loader=loader,
@@ -378,10 +373,9 @@ def _replace_refs(
             _path=path,
             _store=store,
         )
-
     # If our obj was not a json reference object, iterate through it,
     # replacing children with JsonRefs
-    if isinstance(obj, Mapping):
+    elif isinstance(obj, Mapping):
         obj = {
             k: _replace_refs(
                 v,

--- a/jsonref.py
+++ b/jsonref.py
@@ -152,9 +152,13 @@ class JsonRef(LazyProxy):
             and isinstance(result, Mapping)
             and len(self.__reference__) > 1
         ):
+            extra_props = {k: v for k, v in self.__reference__.items() if k != "$ref"}
+            extra_props = _replace_refs(
+                extra_props, **{**self._ref_kwargs, "recursing": True}
+            )
             result = {
                 **result,
-                **{k: v for k, v in self.__reference__.items() if k != "$ref"},
+                **extra_props,
             }
         return result
 

--- a/tests.py
+++ b/tests.py
@@ -234,6 +234,16 @@ class TestJsonRef(object):
         result = replace_refs(json1, base_uri="/json1", loader=loader)
         assert result["a"].__subject__ is result
 
+    def test_self_referent_reference(self):
+        json = {"$ref": "#/sub", "sub": [1, 2]}
+        result = replace_refs(json)
+        assert result == json["sub"]
+
+    def test_self_referent_reference_w_merge(self):
+        json = {"$ref": "#/sub", "extra": "aoeu", "sub": {"main": "aoeu"}}
+        result = replace_refs(json, merge_props=True)
+        assert result == {"main": "aoeu", "extra": "aoeu", "sub": {"main": "aoeu"}}
+
     def test_custom_loader(self):
         data = {"$ref": "foo"}
         loader = mock.Mock(return_value=42)

--- a/tests.py
+++ b/tests.py
@@ -113,6 +113,18 @@ class TestJsonRef(object):
             }
         }
 
+    def test_refs_inside_extra_props(self):
+        """This seems really dubious... but OpenAPI 3.1 spec does it."""
+        docs = {
+            "a.json": {
+                "file": "a",
+                "b": {"$ref": "b.json#/ba", "extra": {"$ref": "b.json#/bb"}},
+            },
+            "b.json": {"ba": {"a": 1}, "bb": {"b": 2}},
+        }
+        result = replace_refs(docs["a.json"], loader=docs.get, merge_props=True)
+        assert result == {"file": "a", "b": {"a": 1, "extra": {"b": 2}}}
+
     def test_recursive_extra(self, parametrized_replace_refs):
         json = {"a": {"$ref": "#", "extra": "foo"}}
         result = parametrized_replace_refs(json, merge_props=True)


### PR DESCRIPTION
This actually fixes/implements a few things:
- Fixes documents where the root is a reference object not being cached
- Allows a reference object to refer to a fragment within itself. fix #51, #40
- Extra properties of a reference object will now have references resolved. (only relevant when merge_props is on)