### PR TITLE
Migrate to pdm-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ version = { source = "file", path = "jsonref.py" }
 includes = ["jsonref.py", "proxytypes.py"]
 
 [build-system]
-requires = ["pdm-pep517>=1.0.0"]
-build-backend = "pdm.pep517.api"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Migrate from the deprecated pdm-pep517 backend to pdm-backend that superseded it.  This required no changes to the project configuration and generated equivalent artifacts.  The migration guide is at: https://pdm-backend.fming.dev/migration/