### PR TITLE
send kwargs into loader

### DIFF
--- a/jsonref/__init__.py
+++ b/jsonref/__init__.py
@@ -127,7 +127,7 @@ class JsonRef(LazyProxy):
         if uri not in self.store:
             # Remote ref
             try:
-                base_doc = self.loader(uri)
+                base_doc = self.loader(uri, **self._ref_kwargs)
             except Exception as e:
                 raise self._error(
                     "%s: %s" % (e.__class__.__name__, str(e)), cause=e


### PR DESCRIPTION
In order to be able to better understand the loading instance in the custom loader, would be nice to pass the kwargs into it. Then we can figure out from which node the ref was resolved.

Specific use case:
I have a json with refs, and I need to collect all those ref'ed jsons.
I'm doing it with custom loader that not only loads ref'ed documents but also registers each of them in the cache.
Then I need to be able to tell from which node this ref was coming. Don't really want to read through the document once again as we already traversing it.
Thanks